### PR TITLE
Expose redefine as the exports

### DIFF
--- a/src/redefine.js
+++ b/src/redefine.js
@@ -169,6 +169,10 @@ var _ = this._ = function(_, Function, Object) {
   redefine.from = from;
   redefine.later = later;
   redefine.defaults = {};
+  
+  if ("undefined" !== typeof module && module.exports) {
+    module.exports = redefine;
+  }
 
   // there you are ...
   _.redefine = redefine;


### PR DESCRIPTION
This makes the node API cleaner.

Now it's `var redefine = require("redefine")` 
instead of `var redefine = require("redefine").redefine`
